### PR TITLE
Ethereum building blocks

### DIFF
--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -75,6 +75,8 @@ class TimeAttestation:
             r = PendingAttestation.deserialize(payload_ctx)
         elif tag == BitcoinBlockHeaderAttestation.TAG:
             r = BitcoinBlockHeaderAttestation.deserialize(payload_ctx)
+        elif tag == EthereumBlockHeaderAttestation.TAG:
+            r = EthereumBlockHeaderAttestation.deserialize(payload_ctx)
         else:
             return UnknownAttestation(tag, serialized_attestation)
 
@@ -326,7 +328,7 @@ class EthereumBlockHeaderAttestation(TimeAttestation):
 
         if len(digest) != 32:
             raise VerificationError("Expected digest with length 32 bytes; got %d bytes" % len(digest))
-        elif digest != bytes.fromhex(block['transactionsRoot']):
+        elif digest != bytes.fromhex(block['transactionsRoot'][2:]):
             raise VerificationError("Digest does not match merkleroot")
 
         return block['timestamp']

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -288,3 +288,56 @@ class BitcoinBlockHeaderAttestation(TimeAttestation):
     def deserialize(cls, ctx):
         height = ctx.read_varuint()
         return BitcoinBlockHeaderAttestation(height)
+
+
+
+class EthereumBlockHeaderAttestation(TimeAttestation):
+    """Signed by the Ethereum blockchain
+
+    The commitment digest will be the merkleroot of the blockheader.
+    """
+
+    TAG = bytes.fromhex('30fe8087b5c7ead7')
+
+    def __init__(self, height):
+        self.height = height
+
+    def __eq__(self, other):
+        if other.__class__ is EthereumBlockHeaderAttestation:
+            return self.height == other.height
+        else:
+            super().__eq__(other)
+
+    def __lt__(self, other):
+        if other.__class__ is EthereumBlockHeaderAttestation:
+            return self.height < other.height
+
+        else:
+            super().__lt__(other)
+
+    def __hash__(self):
+        return hash(self.height)
+
+    def verify_against_blockheader(self, digest, block):
+        """Verify attestation against a block header
+
+        Returns the block time on success; raises VerificationError on failure.
+        """
+
+        if len(digest) != 32:
+            raise VerificationError("Expected digest with length 32 bytes; got %d bytes" % len(digest))
+        elif digest != bytes.fromhex(block['transactionsRoot']):
+            raise VerificationError("Digest does not match merkleroot")
+
+        return block['timestamp']
+
+    def __repr__(self):
+        return 'EthereumBlockHeaderAttestation(%r)' % self.height
+
+    def _serialize_payload(self, ctx):
+        ctx.write_varuint(self.height)
+
+    @classmethod
+    def deserialize(cls, ctx):
+        height = ctx.read_varuint()
+        return EthereumBlockHeaderAttestation(height)

--- a/opentimestamps/core/op.py
+++ b/opentimestamps/core/op.py
@@ -336,22 +336,10 @@ class OpSHA256(CryptOp):
     DIGEST_LENGTH = 32
 
 
-# https://tools.ietf.org/html/draft-jivsov-openpgp-sha3-01
-#
-#                 ID   Algorithm                   Text Name
-#               ------ --------------------------- ----------
-#                 13   SHA-3 with 256 bit output   "SHA3-256"
-#                 14   SHA-3 with 384 bit output   "SHA3-384"
-#                 15   SHA-3 with 512 bit output   "SHA3-512"
-#
-#                100 to 110 - Private/Experimental algorithm 
-
-
 @CryptOp._register_op
 class OpKECCAK256(UnaryOp):
     __slots__ = []
-    SUBCLS_BY_TAG = {}
-    TAG = b'\x69'  # TODO define, use experimental
+    TAG = b'\x67'
     TAG_NAME = 'keccak256'
     DIGEST_LENGTH = 32
 

--- a/opentimestamps/core/op.py
+++ b/opentimestamps/core/op.py
@@ -11,7 +11,7 @@
 
 import binascii
 import hashlib
-
+import sha3
 import opentimestamps.core.serialize
 
 class MsgValueError(ValueError):
@@ -334,3 +334,16 @@ class OpSHA256(CryptOp):
     TAG_NAME = 'sha256'
     HASHLIB_NAME = "sha256"
     DIGEST_LENGTH = 32
+
+@CryptOp._register_op
+class OpKECCAK256(UnaryOp):
+    __slots__ = []
+    SUBCLS_BY_TAG = {}
+    TAG = b'\x18'  # TODO define
+    TAG_NAME = 'keccak256'
+    DIGEST_LENGTH = 32
+
+    def _do_op_call(self, msg):
+        r = sha3.keccak_256(bytes(msg)).digest()
+        assert len(r) == self.DIGEST_LENGTH
+        return r

--- a/opentimestamps/core/op.py
+++ b/opentimestamps/core/op.py
@@ -335,11 +335,23 @@ class OpSHA256(CryptOp):
     HASHLIB_NAME = "sha256"
     DIGEST_LENGTH = 32
 
+
+# https://tools.ietf.org/html/draft-jivsov-openpgp-sha3-01
+#
+#                 ID   Algorithm                   Text Name
+#               ------ --------------------------- ----------
+#                 13   SHA-3 with 256 bit output   "SHA3-256"
+#                 14   SHA-3 with 384 bit output   "SHA3-384"
+#                 15   SHA-3 with 512 bit output   "SHA3-512"
+#
+#                100 to 110 - Private/Experimental algorithm 
+
+
 @CryptOp._register_op
 class OpKECCAK256(UnaryOp):
     __slots__ = []
     SUBCLS_BY_TAG = {}
-    TAG = b'\x18'  # TODO define
+    TAG = b'\x69'  # TODO define, use experimental
     TAG_NAME = 'keccak256'
     DIGEST_LENGTH = 32
 

--- a/opentimestamps/core/timestamp.py
+++ b/opentimestamps/core/timestamp.py
@@ -345,7 +345,7 @@ def make_merkle_tree(timestamps, binop=cat_sha256):
         next_stamps = []
         for stamp in stamps:
             if prev_stamp is not None:
-                next_stamps.append(cat_sha256(prev_stamp, stamp))
+                next_stamps.append(binop(prev_stamp, stamp))
                 prev_stamp = None
             else:
                 prev_stamp = stamp

--- a/opentimestamps/tests/core/test_notary.py
+++ b/opentimestamps/tests/core/test_notary.py
@@ -97,3 +97,24 @@ class Test_BitcoinBlockHeaderAttestation(unittest.TestCase):
                                                         'ff')) # one byte of trailing garbage
         with self.assertRaises(TrailingGarbageError):
             TimeAttestation.deserialize(ctx)
+
+
+class Test_EthereumBlockHeaderAttestation(unittest.TestCase):
+    def test_serialize(self):
+        attestation = EthereumBlockHeaderAttestation(0)
+        expected_serialized = bytes.fromhex('30fe8087b5c7ead7' + '0100')
+
+        ctx = BytesSerializationContext()
+        attestation.serialize(ctx)
+        self.assertEqual(ctx.getbytes(), expected_serialized)
+
+        ctx = BytesDeserializationContext(expected_serialized)
+        attestation2 = TimeAttestation.deserialize(ctx)
+
+        self.assertEqual(attestation2.height, 0)
+
+    def test_verify(self):
+        eth_block_1 = {'uncles': [], 'size': 537, 'hash': '0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6', 'gasLimit': 5000, 'number': 1, 'totalDifficulty': 34351349760, 'stateRoot': '0xd67e4d450343046425ae4271474353857ab860dbc0a1dde64b41b5cd3a532bf3', 'extraData': '0x476574682f76312e302e302f6c696e75782f676f312e342e32', 'sha3Uncles': '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347', 'mixHash': '0x969b900de27b6ac6a67742365dd65f55a0526c41fd18e1b16f1a1215c2e66f59', 'transactionsRoot': '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421', 'sealFields': ['0x969b900de27b6ac6a67742365dd65f55a0526c41fd18e1b16f1a1215c2e66f59', '0x539bd4979fef1ec4'], 'transactions': [], 'parentHash': '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3', 'logsBloom': '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 'author': '0x05a56e2d52c817161883f50c441c3228cfe54d9f', 'gasUsed': 0, 'timestamp': 1438269988, 'nonce': '0x539bd4979fef1ec4', 'difficulty': 17171480576, 'receiptsRoot': '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421', 'miner': '0x05a56e2d52c817161883f50c441c3228cfe54d9f'}
+        attestation = EthereumBlockHeaderAttestation(1)
+        timestamp = attestation.verify_against_blockheader(bytes.fromhex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"), eth_block_1)
+        self.assertEqual(1438269988, timestamp)

--- a/opentimestamps/tests/core/test_op.py
+++ b/opentimestamps/tests/core/test_op.py
@@ -101,3 +101,8 @@ class Test_Op(unittest.TestCase):
         """Operation ordering"""
         self.assertTrue(OpSHA1() < OpRIPEMD160())
         # FIXME: more tests
+
+    def test_keccak256(self):
+        """KECCAK256 operation"""
+        self.assertEqual(OpKECCAK256()(b''), bytes.fromhex('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'))
+        self.assertEqual(OpKECCAK256()(b'\x80'), bytes.fromhex('56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-bitcoinlib>=0.7.0
 GitPython>=2.0.8
+pysha3>=1.0.2


### PR DESCRIPTION
Adding Keccak hash operation using sha3 library (not yet a standard hash)
Using TAG 103 (hex 67) which is reserved for experimental algo by rfc4880 (there is a [standardization](https://tools.ietf.org/html/draft-jivsov-openpgp-sha3-01) request for sha3 but ethereum doesn't use the standard sha3)

Adding EthereumBlockHeaderAttestation using standard block dict names for ethereum

Adding tests for both
