### PR TITLE
added LitecoinBlockHeaderAttestation

### DIFF
--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -306,9 +306,9 @@ class LitecoinBlockHeaderAttestation(TimeAttestation):
     of an attestation on OpenTimestamps is always zero.
 
     However, a highly motivated calendar server could have an attestion transaction 
-    in every block every 2.5 minutes on Litecoin, which provides a more
-    granular proof of existence than Bitcoin. A user could have a highly secure 
-    attestation the bitcoin blockchain and a precise one on an altchain such as Litecoin.
+    in every block every 2.5 minutes on Litecoin, which provides a faster confirmation
+    than Bitcoin. A user could fetch a highly secure attestation the bitcoin blockchain 
+    and immediately get one on an altchain such as Litecoin.
     
     """
 

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -299,17 +299,6 @@ class LitecoinBlockHeaderAttestation(TimeAttestation):
     """Signed by the Litecoin blockchain
 
     Identical in design to the BitcoinBlockHeaderAttestation.
-
-    There are very few advantages to using altcoins attestations, primarly because
-    the resources spent to secure those chains are much lower, but also because
-    even if the fees are sometimes lower on other chain, the marginal cost
-    of an attestation on OpenTimestamps is always zero.
-
-    However, a highly motivated calendar server could have an attestion transaction 
-    in every block every 2.5 minutes on Litecoin, which provides a faster confirmation
-    than Bitcoin. A user could fetch a highly secure attestation the bitcoin blockchain 
-    and immediately get one on an altchain such as Litecoin.
-    
     """
 
     TAG = bytes.fromhex('06869a0d73d71b45')

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -79,6 +79,8 @@ class TimeAttestation:
             r = PendingAttestation.deserialize(payload_ctx)
         elif tag == BitcoinBlockHeaderAttestation.TAG:
             r = BitcoinBlockHeaderAttestation.deserialize(payload_ctx)
+        elif tag == LitecoinBlockHeaderAttestation.TAG:
+            r = LitecoinBlockHeaderAttestation.deserialize(payload_ctx)
         elif tag == opentimestamps.core.dubious.notary.EthereumBlockHeaderAttestation.TAG:
             r = opentimestamps.core.dubious.notary.EthereumBlockHeaderAttestation.deserialize(payload_ctx)
         else:
@@ -325,15 +327,11 @@ class LitecoinBlockHeaderAttestation(TimeAttestation):
     def verify_against_blockheader(self, digest, block_header):
         """Verify attestation against a block header
 
-        Returns the block time on success; raises VerificationError on failure.
+        Not implemented here until there is a well-maintained Litecoin 
+        python library
         """
+        raise NotImplementedError()
 
-        if len(digest) != 32:
-            raise VerificationError("Expected digest with length 32 bytes; got %d bytes" % len(digest))
-        elif digest != block_header.hashMerkleRoot:
-            raise VerificationError("Digest does not match merkleroot")
-
-        return block_header.nTime
 
     def __repr__(self):
         return 'LitecoinBlockHeaderAttestation(%r)' % self.height

--- a/opentimestamps/core/timestamp.py
+++ b/opentimestamps/core/timestamp.py
@@ -14,7 +14,7 @@ import binascii
 from bitcoin.core import CTransaction, SerializationError, b2lx, b2x
 
 from opentimestamps.core.op import Op, CryptOp, OpSHA256, OpAppend, OpPrepend, MsgValueError
-from opentimestamps.core.notary import TimeAttestation, BitcoinBlockHeaderAttestation
+from opentimestamps.core.notary import TimeAttestation, BitcoinBlockHeaderAttestation, LitecoinBlockHeaderAttestation
 
 import opentimestamps.core.serialize
 
@@ -233,12 +233,14 @@ class Timestamp:
                 r += " "*indent + "verify %s" % str(attestation) + str_result(verbosity, self.msg, None) + "\n"
                 if attestation.__class__ == BitcoinBlockHeaderAttestation:
                     r += " "*indent + "# Bitcoin block merkle root " + b2lx(self.msg) + "\n"
+                if attestation.__class__ == LitecoinBlockHeaderAttestation:
+                    r += " "*indent + "# Litecoin block merkle root " + b2lx(self.msg) + "\n"
 
         if len(self.ops) > 1:
             for op, timestamp in sorted(self.ops.items()):
                 try:
                     CTransaction.deserialize(self.msg)
-                    r += " " * indent + "* Bitcoin transaction id " + b2lx(
+                    r += " " * indent + "* Transaction id " + b2lx(
                         OpSHA256()(OpSHA256()(self.msg))) + "\n"
                 except SerializationError:
                     pass
@@ -249,7 +251,7 @@ class Timestamp:
         elif len(self.ops) > 0:
             try:
                 CTransaction.deserialize(self.msg)
-                r += " " * indent + "# Bitcoin transaction id " + \
+                r += " " * indent + "# Transaction id " + \
                      b2lx(OpSHA256()(OpSHA256()(self.msg))) + "\n"
             except SerializationError:
                 pass


### PR DESCRIPTION
Litecoin is a bit annoying because it doesn't have RBF yet, but it is very useful for getting very granular timestamps. 

I already have a forked (and _very_ hacky) version of opentimestamps-server that works with Litecoin, and I'm working right now on making those change properly and proposing them upstream. 

It's very likely I'm going to have the budget (and the need) to run a public Litecoin calendar that has a transaction in every block, and I'd much prefer it to be part of the OTS standard.

Any thoughts?