### PR TITLE
precomputing serialized tx once for performance reason

### DIFF
--- a/opentimestamps/bitcoin.py
+++ b/opentimestamps/bitcoin.py
@@ -32,7 +32,7 @@ def __make_btc_block_merkle_tree(blk_txids):
     return digests[0]
 
 
-def make_timestamp_from_block(digest, block, blockheight, *, max_tx_size=1000):
+def make_timestamp_from_block(digest, block, blockheight, *, max_tx_size=1000, serde_txs=None):
     """Make a timestamp for a message in a block
 
     Every transaction within the block is serialized and checked to see if the
@@ -51,8 +51,14 @@ def make_timestamp_from_block(digest, block, blockheight, *, max_tx_size=1000):
     commitment_tx = None
     prefix = None
     suffix = None
-    for tx in block.vtx:
-        serialized_tx = tx.serialize(params={'include_witness':False})
+
+    # Populate serde_txs if it is not already precomputed
+    if serde_txs is None:
+        serde_txs = []
+        for tx in block.vtx:
+            serde_txs.append((tx, tx.serialize(params={'include_witness':False})))
+
+    for (tx, serialized_tx) in serde_txs:
 
         if len(serialized_tx) > len_smallest_tx_found:
             continue

--- a/opentimestamps/tests/test_bitcoin.py
+++ b/opentimestamps/tests/test_bitcoin.py
@@ -60,3 +60,18 @@ class Test_make_timestamp_from_block(unittest.TestCase):
         (msg, attestation) = tuple(root_stamp.all_attestations())[0]
         self.assertEqual(msg, lx('28a5b26b232d9dca49418abe0be60e375fd81729b44c676f44e585d4597ba5fb')) # merkleroot
         self.assertEqual(attestation.height, 129)
+
+    def test_bench(self):
+        # This is not a proper test but a benchmark, to check the precomputing of serialized tx once allow
+        # to call make_timestamp_from_block many times without waiting too much
+        try:
+            proxy = bitcoin.rpc.Proxy()
+            block = proxy.getblock(lx('0000000000000000001d34d4434c1223a5b9b7298714cafa85cb1b139b3d9f1b'))
+            digest = lx('0000000000000000001d34d4434c1223a5b9b7298714cafa85cb1b139b3d9f1b')
+            serde_txs = []
+            for tx in block.vtx:
+                serde_txs.append((tx, tx.serialize()))
+            for i in range(0, 300):
+                make_timestamp_from_block(digest, block, 0, serde_txs=serde_txs)
+        except:
+            pass


### PR DESCRIPTION
PR to resolve performance issue discussed in https://github.com/opentimestamps/opentimestamps-server/pull/24