### PR TITLE
use urljoin to create url instead of string concat

### DIFF
--- a/opentimestamps/calendar.py
+++ b/opentimestamps/calendar.py
@@ -13,6 +13,7 @@ import binascii
 import urllib.request
 import fnmatch
 
+from urllib.parse import urljoin
 from opentimestamps.core.timestamp import Timestamp
 from opentimestamps.core.serialize import BytesDeserializationContext
 
@@ -59,7 +60,7 @@ class RemoteCalendar:
 
         Returns a Timestamp committing to that digest
         """
-        req = urllib.request.Request(self.url + '/digest', data=digest, headers=self.request_headers)
+        req = urllib.request.Request(urljoin(self.url, '/digest'), data=digest, headers=self.request_headers)
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status != 200:
                 raise Exception("Unknown response from calendar: %d" % resp.status)
@@ -78,8 +79,9 @@ class RemoteCalendar:
 
         Raises KeyError if the calendar doesn't have that commitment
         """
-        req = urllib.request.Request(self.url + '/timestamp/' + binascii.hexlify(commitment).decode('utf8'),
-                                     headers=self.request_headers)
+        req = urllib.request.Request(
+            urljoin(urljoin(self.url, '/timestamp/'), binascii.hexlify(commitment).decode('utf8')),
+            headers=self.request_headers)
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 if resp.status == 200:

--- a/opentimestamps/calendar.py
+++ b/opentimestamps/calendar.py
@@ -60,7 +60,8 @@ class RemoteCalendar:
 
         Returns a Timestamp committing to that digest
         """
-        req = urllib.request.Request(urljoin(self.url, '/digest'), data=digest, headers=self.request_headers)
+        req = urllib.request.Request(urljoin(self.url, 'digest'), data=digest, headers=self.request_headers)
+
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status != 200:
                 raise Exception("Unknown response from calendar: %d" % resp.status)
@@ -80,7 +81,7 @@ class RemoteCalendar:
         Raises KeyError if the calendar doesn't have that commitment
         """
         req = urllib.request.Request(
-            urljoin(urljoin(self.url, '/timestamp/'), binascii.hexlify(commitment).decode('utf8')),
+            urljoin(self.url, 'timestamp/' + binascii.hexlify(commitment).decode('utf8')),
             headers=self.request_headers)
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:


### PR DESCRIPTION
More than one time happened to me a command like this `ots stamp -c https://ots.ltc.catallaxy.com/ -c https://finney.calendar.eternitywall.com/ examples/ltc-and-btc.txt` was failing.
More than one time I didn't remember the trailing slash cause problem and the correct command is: `ots stamp -c https://ots.ltc.catallaxy.com -c https://finney.calendar.eternitywall.com examples/ltc-and-btc.txt`
This PR join url with `urllib` such that the two above command are both valid