### PR TITLE
Set long_description_content_type for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
 
     description='Create and verify OpenTimestamps proofs',
     long_description=long_description,
+    long_description_content_type='text/markdown',
 
     # The project's main homepage.
     url='https://github.com/opentimestamps/python-opentimestamps',


### PR DESCRIPTION
Enables markdown `long_description` to be rendered on PyPI.

Currently https://pypi.org/project/opentimestamps/ looks like:

![ots-pypi](https://user-images.githubusercontent.com/1117703/39265576-99df7102-4895-11e8-8cf5-f4776d730fcb.png)
