### PR TITLE
minor: fix str_tree()

### DIFF
--- a/opentimestamps/core/timestamp.py
+++ b/opentimestamps/core/timestamp.py
@@ -245,7 +245,7 @@ class Timestamp:
                 except SerializationError:
                     pass
                 cur_res = op(self.msg)
-                cur_par = op[0]
+                cur_par = op[0] if len(op) > 0 else None
                 r += " " * indent + " -> " + "%s" % str(op) + str_result(verbosity, cur_par, cur_res) + "\n"
                 r += timestamp.str_tree(indent+4, verbosity=verbosity)
         elif len(self.ops) > 0:

--- a/opentimestamps/tests/core/test_timestamp.py
+++ b/opentimestamps/tests/core/test_timestamp.py
@@ -122,6 +122,13 @@ class Test_Timestamp(unittest.TestCase):
         with self.assertRaises(RecursionLimitError):
             Timestamp.deserialize(BytesDeserializationContext(serialized), b'')
 
+    def test_str_tree(self):
+        """Converting timestamp to tree"""
+        t = Timestamp(b'')
+        t.ops.add(OpAppend(b'\x01'))
+        t.ops.add(OpSHA256())
+        self.assertEqual(t.str_tree(), " -> sha256\n -> append 01\n")
+
 class Test_DetachedTimestampFile(unittest.TestCase):
     def test_create_from_file(self):
         file_stamp = DetachedTimestampFile.from_fd(OpSHA256(), io.BytesIO(b''))


### PR DESCRIPTION
If a `Timestamp` has multiple `Op`s and at least one of those is a `UnaryOp`, then `str_tree()` fails.