### PR TITLE
fix attestation comparison

### DIFF
--- a/opentimestamps/core/dubious/notary.py
+++ b/opentimestamps/core/dubious/notary.py
@@ -35,14 +35,14 @@ class EthereumBlockHeaderAttestation(notary.TimeAttestation):
         if other.__class__ is EthereumBlockHeaderAttestation:
             return self.height == other.height
         else:
-            super().__eq__(other)
+            return super().__eq__(other)
 
     def __lt__(self, other):
         if other.__class__ is EthereumBlockHeaderAttestation:
             return self.height < other.height
 
         else:
-            super().__lt__(other)
+            return super().__lt__(other)
 
     def __hash__(self):
         return hash(self.height)

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -105,9 +105,11 @@ class UnknownAttestation(TimeAttestation):
         elif len(payload) > self.MAX_PAYLOAD_SIZE:
             raise ValueError("payload must be <= %d bytes long; got %d" % (self.MAX_PAYLOAD_SIZE, len(payload)))
 
-        # FIXME: we should check that tag != one of the tags that we do know
-        # about; if it does the operators < and =, and hash() will likely act
-        # strangely
+        # check that tag != one of the tags that we do know about; if it does
+        # the operators < and =, and hash() will likely act strangely
+        if tag in [bytes.fromhex('83dfe30d2ef90c8e'), bytes.fromhex('0588960d73d71901'),
+                   bytes.fromhex('06869a0d73d71b45'), bytes.fromhex('30fe8087b5c7ead7')]:
+            raise ValueError("UnknownAttestation tag must be different from other attestations tags")
         self.TAG = tag
         self.payload = payload
 

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -105,11 +105,9 @@ class UnknownAttestation(TimeAttestation):
         elif len(payload) > self.MAX_PAYLOAD_SIZE:
             raise ValueError("payload must be <= %d bytes long; got %d" % (self.MAX_PAYLOAD_SIZE, len(payload)))
 
-        # check that tag != one of the tags that we do know about; if it does
-        # the operators < and =, and hash() will likely act strangely
-        if tag in [bytes.fromhex('83dfe30d2ef90c8e'), bytes.fromhex('0588960d73d71901'),
-                   bytes.fromhex('06869a0d73d71b45'), bytes.fromhex('30fe8087b5c7ead7')]:
-            raise ValueError("UnknownAttestation tag must be different from other attestations tags")
+        # FIXME: we should check that tag != one of the tags that we do know
+        # about; if it does the operators < and =, and hash() will likely act
+        # strangely
         self.TAG = tag
         self.payload = payload
 

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -124,7 +124,7 @@ class UnknownAttestation(TimeAttestation):
         if other.__class__ is UnknownAttestation:
             return (self.TAG, self.payload) < (other.TAG, other.payload)
         else:
-            super().__eq__(other)
+            super().__lt__(other)
 
     def __hash__(self):
         return hash((self.TAG, self.payload))
@@ -205,7 +205,7 @@ class PendingAttestation(TimeAttestation):
             return self.uri < other.uri
 
         else:
-            super().__eq__(other)
+            super().__lt__(other)
 
     def __hash__(self):
         return hash(self.uri)
@@ -268,7 +268,7 @@ class BitcoinBlockHeaderAttestation(TimeAttestation):
             return self.height < other.height
 
         else:
-            super().__eq__(other)
+            super().__lt__(other)
 
     def __hash__(self):
         return hash(self.height)
@@ -319,7 +319,7 @@ class LitecoinBlockHeaderAttestation(TimeAttestation):
             return self.height < other.height
 
         else:
-            super().__eq__(other)
+            super().__lt__(other)
 
     def __hash__(self):
         return hash(self.height)

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -122,7 +122,7 @@ class UnknownAttestation(TimeAttestation):
 
     def __lt__(self, other):
         if other.__class__ is UnknownAttestation:
-            return (self.tag, self.payload) < (other.tag, other.payload)
+            return (self.TAG, self.payload) < (other.TAG, other.payload)
         else:
             super().__eq__(other)
 

--- a/opentimestamps/core/notary.py
+++ b/opentimestamps/core/notary.py
@@ -118,13 +118,13 @@ class UnknownAttestation(TimeAttestation):
         if other.__class__ is UnknownAttestation:
             return self.TAG == other.TAG and self.payload == other.payload
         else:
-            super().__eq__(other)
+            return super().__eq__(other)
 
     def __lt__(self, other):
         if other.__class__ is UnknownAttestation:
             return (self.TAG, self.payload) < (other.TAG, other.payload)
         else:
-            super().__lt__(other)
+            return super().__lt__(other)
 
     def __hash__(self):
         return hash((self.TAG, self.payload))
@@ -198,14 +198,14 @@ class PendingAttestation(TimeAttestation):
         if other.__class__ is PendingAttestation:
             return self.uri == other.uri
         else:
-            super().__eq__(other)
+            return super().__eq__(other)
 
     def __lt__(self, other):
         if other.__class__ is PendingAttestation:
             return self.uri < other.uri
 
         else:
-            super().__lt__(other)
+            return super().__lt__(other)
 
     def __hash__(self):
         return hash(self.uri)
@@ -261,14 +261,14 @@ class BitcoinBlockHeaderAttestation(TimeAttestation):
         if other.__class__ is BitcoinBlockHeaderAttestation:
             return self.height == other.height
         else:
-            super().__eq__(other)
+            return super().__eq__(other)
 
     def __lt__(self, other):
         if other.__class__ is BitcoinBlockHeaderAttestation:
             return self.height < other.height
 
         else:
-            super().__lt__(other)
+            return super().__lt__(other)
 
     def __hash__(self):
         return hash(self.height)
@@ -312,14 +312,14 @@ class LitecoinBlockHeaderAttestation(TimeAttestation):
         if other.__class__ is LitecoinBlockHeaderAttestation:
             return self.height == other.height
         else:
-            super().__eq__(other)
+            return super().__eq__(other)
 
     def __lt__(self, other):
         if other.__class__ is LitecoinBlockHeaderAttestation:
             return self.height < other.height
 
         else:
-            super().__lt__(other)
+            return super().__lt__(other)
 
     def __hash__(self):
         return hash(self.height)

--- a/opentimestamps/tests/core/test_notary.py
+++ b/opentimestamps/tests/core/test_notary.py
@@ -103,5 +103,3 @@ class Test_AttestationsComparison(unittest.TestCase):
         """Comparing attestations"""
         self.assertTrue(UnknownAttestation(b'unknown1', b'') < UnknownAttestation(b'unknown2', b''))
         self.assertTrue(BitcoinBlockHeaderAttestation(1) < PendingAttestation(""))
-        with self.assertRaises(ValueError):
-            UnknownAttestation(PendingAttestation("").TAG, b'')

--- a/opentimestamps/tests/core/test_notary.py
+++ b/opentimestamps/tests/core/test_notary.py
@@ -97,3 +97,11 @@ class Test_BitcoinBlockHeaderAttestation(unittest.TestCase):
                                                         'ff')) # one byte of trailing garbage
         with self.assertRaises(TrailingGarbageError):
             TimeAttestation.deserialize(ctx)
+
+class Test_AttestationsComparison(unittest.TestCase):
+    def test_attestation_comparison(self):
+        """Comparing attestations"""
+        self.assertTrue(UnknownAttestation(b'unknown1', b'') < UnknownAttestation(b'unknown2', b''))
+        self.assertTrue(BitcoinBlockHeaderAttestation(1) < PendingAttestation(""))
+        with self.assertRaises(ValueError):
+            UnknownAttestation(PendingAttestation("").TAG, b'')


### PR DESCRIPTION
When comparing attestations, some unexpected behaviors occur.

`UnknownAttestation(b'unknown1', b'') < UnknownAttestation(b'unknown2', b'')` raises `AttributeError`.

`BitcoinBlockHeaderAttestation(1) < PendingAttestation("")` returns `None`.

Right before 89632d005e3ee1951b62328697722a2ef9472a85, 
```
UnknownAttestation(PendingAttestation("").TAG, b'') < PendingAttestation("")
UnknownAttestation(PendingAttestation("").TAG, b'') == PendingAttestation("")
UnknownAttestation(PendingAttestation("").TAG, b'') > PendingAttestation("")
``` 
are all `False`.
