### PR TITLE
fix timestamp equality

### DIFF
--- a/opentimestamps/core/timestamp.py
+++ b/opentimestamps/core/timestamp.py
@@ -74,7 +74,7 @@ class Timestamp:
 
     def __eq__(self, other):
         if isinstance(other, Timestamp):
-            return self.__msg == other.__msg and self.ops == other.ops
+            return self.__msg == other.__msg and self.attestations == other.attestations and self.ops == other.ops
         else:
             return False
 

--- a/opentimestamps/tests/core/test_timestamp.py
+++ b/opentimestamps/tests/core/test_timestamp.py
@@ -129,6 +129,15 @@ class Test_Timestamp(unittest.TestCase):
         t.ops.add(OpSHA256())
         self.assertEqual(t.str_tree(), " -> sha256\n -> append 01\n")
 
+    def test_equality(self):
+        """Checking timestamp equality"""
+        t1 = Timestamp(b'')
+        t1.attestations = {BitcoinBlockHeaderAttestation(1), PendingAttestation("")}
+        t2 = Timestamp(b'')
+        self.assertFalse(t1 == t2)
+        t2.attestations = {PendingAttestation(""), BitcoinBlockHeaderAttestation(1)}
+        self.assertTrue(t1 == t2)
+
 class Test_DetachedTimestampFile(unittest.TestCase):
     def test_create_from_file(self):
         file_stamp = DetachedTimestampFile.from_fd(OpSHA256(), io.BytesIO(b''))


### PR DESCRIPTION
As pointed out in https://github.com/opentimestamps/java-opentimestamps/issues/11, `Timestamp` equality must check that attestations are equal. 