### PR TITLE
Mark python-bitcoinlib 0.11 as compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python-bitcoinlib>=0.9.0,<0.11.0
+python-bitcoinlib>=0.9.0,<0.12.0
 GitPython>=2.0.8
 pysha3>=1.0.2

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['python-bitcoinlib>=0.9.0,<0.11.0',
+    install_requires=['python-bitcoinlib>=0.9.0,<0.12.0',
                       'pysha3>=1.0.2'],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Tried simple `ots stamp`, `ots verify` and `ots info` and they seem to work fine.