### PR TITLE
Replace pysha3 with pycryptodomex

### DIFF
--- a/opentimestamps/core/op.py
+++ b/opentimestamps/core/op.py
@@ -10,8 +10,8 @@
 # in the LICENSE file.
 
 import binascii
+import Cryptodome.Hash.keccak
 import hashlib
-import sha3
 import opentimestamps.core.serialize
 
 class MsgValueError(ValueError):
@@ -344,6 +344,6 @@ class OpKECCAK256(UnaryOp):
     DIGEST_LENGTH = 32
 
     def _do_op_call(self, msg):
-        r = sha3.keccak_256(bytes(msg)).digest()
+        r = Cryptodome.Hash.keccak.new(digest_bits=256, data=bytes(msg)).digest()
         assert len(r) == self.DIGEST_LENGTH
         return r

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-bitcoinlib>=0.9.0,<0.12.0
 GitPython>=2.0.8
-pysha3>=1.0.2
+pycryptodomex>=3.3.1

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['python-bitcoinlib>=0.9.0,<0.12.0',
-                      'pysha3>=1.0.2'],
+                      'pycryptodomex>=3.3.1'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
pysha3 is not maintained anymore and it doesn't build correctly with Python 3.11 so replace it with pycryptodomex that is still maintained and working correctly with new python versions